### PR TITLE
Alert on error rate in logs: avoid false positives

### DIFF
--- a/scripts/resources/grafana/alerts/logs/error_message_alert.json
+++ b/scripts/resources/grafana/alerts/logs/error_message_alert.json
@@ -19,7 +19,7 @@
           "uid": "{{DATASOURCE_UID}}"
         },
         "editorMode": "code",
-	"expr": "sum by(pod)(count_over_time({app=\"gridsuite\", pod!~\"apps-metadata-server-.*\", pod=~\".*-server-.*\"}| regexp `^(?P<outer_ts>[^ ]+) (?P<stream>[^ ]+) (P|F) (?P<timestamp>[^ ]+)\\s+(?P<level>WARN|DEBUG|INFO|ERROR|TRACE) (?P<pid>\\d+)\\s+---\\s+\\[(?P<server_name>[^\\]]+)\\]\\s+\\[(?P<thread>[^\\]]+)\\]\\s+\\[(?P<trace_id>[^\\]]+)\\]\\s+(?P<class>[^ ]+)\\s+:(?<message>\\s+.*$)` | level= `ERROR` [5m]))",
+	"expr": "sum by(pod)(count_over_time({app=\"gridsuite\", pod!~\"apps-metadata-server-.*\", pod=~\".*-server-.*\"}| regexp `^(?P<outer_ts>[^ ]+) (?P<stream>[^ ]+) (P|F) (?P<timestamp>[^ ]+)\\s+(?P<level>WARN|DEBUG|INFO|ERROR|TRACE) (?P<pid>\\d+)\\s+---\\s+\\[(?P<server_name>[^\\]]+)\\]\\s+\\[(?P<thread>[^\\]]+)\\]\\s+\\[(?P<trace_id>[^\\]]+)\\]\\s+(?P<logger>[^ ]+)\\s+:(?<message>\\s+.*$)` | level= `ERROR` [5m]))",
         "instant": false,
         "interval": "",
         "intervalMs": 15000,

--- a/scripts/resources/grafana/alerts/logs/error_message_alert.json
+++ b/scripts/resources/grafana/alerts/logs/error_message_alert.json
@@ -19,7 +19,7 @@
           "uid": "{{DATASOURCE_UID}}"
         },
         "editorMode": "code",
-        "expr": "count_over_time({pod=~\".+\"} |~ `.+ ERROR .+` [5m])",
+	"expr": "sum by(pod)(count_over_time({app=\"gridsuite\", pod!~\"apps-metadata-server-.*\", pod=~\".*-server-.*\"}| regexp `^(?P<outer_ts>[^ ]+) (?P<stream>[^ ]+) (P|F) (?P<timestamp>[^ ]+)\\s+(?P<level>WARN|DEBUG|INFO|ERROR|TRACE) (?P<pid>\\d+)\\s+---\\s+\\[(?P<server_name>[^\\]]+)\\]\\s+\\[(?P<thread>[^\\]]+)\\]\\s+\\[(?P<trace_id>[^\\]]+)\\]\\s+(?P<class>[^ ]+)\\s+:(?<message>\\s+.*$)` | level= `ERROR` [5m]))",
         "instant": false,
         "interval": "",
         "intervalMs": 15000,


### PR DESCRIPTION
## PR Summary

The alert on error rate in backend services logs uses a regexp that has some false positives. For instance it matches the message which has a url gridsuite.org/logs?severity=ERROR in it.

To avoid these false positive, we suggest to actually parse the log file with a complete pattern then match messages with the level ERROR







